### PR TITLE
Student Can View Module-Specific Activities as a Schedule

### DIFF
--- a/src/features/dashboard/StudentDashboardSection.tsx
+++ b/src/features/dashboard/StudentDashboardSection.tsx
@@ -4,14 +4,20 @@ import { StudentCourseCard } from '../shared/components/student-course-card/Stud
 import { StudentModuleActivities } from '../shared/components/StudentModuleActivities/StudentModuleActivities';
 
 export const StudentDashboardSection: React.FC = () => {
-  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+  const [selectedModule, setSelectedModule] = useState<{
+    id: string;
+    moduleTitle: string;
+  } | null>(null);
 
   return (
     <div>
       <StudentCourseCard />
-      <StudentModuleList onSelectModule={setSelectedModuleId} />
-      {selectedModuleId && (
-        <StudentModuleActivities moduleId={selectedModuleId} />
+      <StudentModuleList onSelectModule={setSelectedModule} />
+      {selectedModule && (
+        <StudentModuleActivities
+          moduleId={selectedModule.id}
+          moduleTitle={selectedModule.moduleTitle}
+        />
       )}
     </div>
   );

--- a/src/features/dashboard/StudentDashboardSection.tsx
+++ b/src/features/dashboard/StudentDashboardSection.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { StudentModuleList } from '../shared/components/StudentModuleList/StudentModuleList';
 import { StudentCourseCard } from '../shared/components/student-course-card/StudentCourseCard';
 import { StudentModuleActivities } from '../shared/components/StudentModuleActivities/StudentModuleActivities';
 
-export const StudentDashboardSection: React.FC = () => (
-  <div>
-    <StudentCourseCard />
-    <StudentModuleActivities />
-    <StudentModuleList />
-  </div>
-);
+export const StudentDashboardSection: React.FC = () => {
+  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+
+  return (
+    <div>
+      <StudentCourseCard />
+      <StudentModuleList onSelectModule={setSelectedModuleId} />
+      {selectedModuleId && (
+        <StudentModuleActivities moduleId={selectedModuleId} />
+      )}
+    </div>
+  );
+};

--- a/src/features/dashboard/StudentDashboardSection.tsx
+++ b/src/features/dashboard/StudentDashboardSection.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { StudentCourseCard } from '../shared/components/student-course-card/StudentCourseCard';
+import StudentModuleActivities from '../shared/components/StudentModuleActivities/StudentModuleActivities';
 
 export const StudentDashboardSection: React.FC = () => (
   <div>
     <StudentCourseCard />
+    <StudentModuleActivities />
   </div>
 );

--- a/src/features/dashboard/StudentDashboardSection.tsx
+++ b/src/features/dashboard/StudentDashboardSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StudentCourseCard } from '../shared/components/student-course-card/StudentCourseCard';
-import StudentModuleActivities from '../shared/components/StudentModuleActivities/StudentModuleActivities';
+import { StudentModuleActivities } from '../shared/components/StudentModuleActivities/StudentModuleActivities';
 
 export const StudentDashboardSection: React.FC = () => (
   <div>

--- a/src/features/shared/components/StudentActivityCard/StudentActivityCard.module.css
+++ b/src/features/shared/components/StudentActivityCard/StudentActivityCard.module.css
@@ -1,0 +1,17 @@
+.student-activity-card {
+  background: white;         
+  border: 1px solid #e4e2e2;             
+  border-radius: 8px;                 
+  padding: 1.5rem;                    
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  width: 100%;
+  max-width: 600px;                   
+  margin: 1rem auto;                  
+}
+
+.student-activity-card-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  color: black;
+}

--- a/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
+++ b/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
@@ -17,12 +17,14 @@ export function StudentActivityCard({
 }: StudentActivityCardProps) {
   return (
     <div className={styles['student-activity-card']}>
-      <p className={styles['student-activity-card-title']}>{activityTitle}</p>
-      <p>{description}</p>
-      <p>Type: {activityTypeName}</p>
-      <p>
-        {startDate}   {endDate}
-      </p>
+      <div className={styles['student-activity-card-title']}>
+        {activityTitle}
+      </div>
+      <div>{description}</div>
+      <div>Type: {activityTypeName}</div>
+      <div>
+        <span>Start: {startDate}</span> | <span>End: {endDate}</span>
+      </div>
     </div>
   );
 }

--- a/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
+++ b/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
@@ -1,13 +1,28 @@
 import styles from './StudentActivityCard.module.css';
 
 interface StudentActivityCardProps {
-  title: string;
+  activityTitle: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  activityTypeName: string;
 }
 
-export function StudentActivityCard({ title }: StudentActivityCardProps) {
+export function StudentActivityCard({
+  activityTitle,
+  description,
+  startDate,
+  endDate,
+  activityTypeName,
+}: StudentActivityCardProps) {
   return (
     <div className={styles['student-activity-card']}>
-      <p className={styles['student-activity-card-title']}>{title}</p>
+      <p className={styles['student-activity-card-title']}>{activityTitle}</p>
+      <p>{description}</p>
+      <p>Type: {activityTypeName}</p>
+      <p>
+        {startDate}   {endDate}
+      </p>
     </div>
   );
 }

--- a/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
+++ b/src/features/shared/components/StudentActivityCard/StudentActivityCard.tsx
@@ -1,0 +1,13 @@
+import styles from './StudentActivityCard.module.css';
+
+interface StudentActivityCardProps {
+  title: string;
+}
+
+export function StudentActivityCard({ title }: StudentActivityCardProps) {
+  return (
+    <div className={styles['student-activity-card']}>
+      <p className={styles['student-activity-card-title']}>{title}</p>
+    </div>
+  );
+}

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.module.css
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.module.css
@@ -1,0 +1,17 @@
+.student-module-activities-card {
+  background: white;         
+  border: 1px solid #e4e2e2;             
+  border-radius: 8px;                 
+  padding: 1.5rem;                    
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  width: 100%;
+  max-width: 600px;                   
+  margin: 1rem auto;                  
+}
+
+.student-module-activities-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  color: black;
+}

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -53,10 +53,12 @@ export function StudentModuleActivities({
   return (
     <div className={styles['student-module-activities-card']}>
       <h2 className={styles['student-module-activities-title']}>
-        Activities for module {moduleTitle}
+        Activities for {moduleTitle}
       </h2>
 
-      {data.map((activity) => (
+      {data
+      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+      .map((activity) => (
         <StudentActivityCard
           key={activity.id}
           activityTitle={activity.activityTitle}

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -1,25 +1,20 @@
-import React from 'react';
 import styles from './StudentModuleActivities.module.css';
+import { StudentActivityCard } from '../StudentActivityCard/StudentActivityCard';
 
-const StudentModuleActivities: React.FC = () => {
-
-    const activities = [
-    { id: 1, title: "Activity number 1" },
-    { id: 2, title: "Activity number 2" },
-    { id: 3, title: "Activity number 3" }
+export function StudentModuleActivities() {
+  const activities = [
+    { id: 1, title: 'Activity number 1' },
+    { id: 2, title: 'Activity number 2' },
+    { id: 3, title: 'Activity number 3' },
   ];
-
 
   return (
     <div className={styles['student-module-activities-card']}>
-        <h2 className={styles['student-module-activities-title']}>Activities</h2>
+      <h2 className={styles['student-module-activities-title']}>Activities</h2>
 
-      {activities.map(activity => (
-        <p key={activity.id}>{activity.title}</p>
+      {activities.map((activity) => (
+        <StudentActivityCard key={activity.id} title={activity.title} />
       ))}
-
     </div>
   );
-};
-
-export default StudentModuleActivities;
+}

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -10,7 +10,7 @@ export function StudentModuleActivities() {
 
   return (
     <div className={styles['student-module-activities-card']}>
-      <h2 className={styles['student-module-activities-title']}>Activities</h2>
+      <h2 className={styles['student-module-activities-title']}>Activities for the module</h2>
 
       {activities.map((activity) => (
         <StudentActivityCard key={activity.id} title={activity.title} />

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './StudentModuleActivities.module.css';
+
+const StudentModuleActivities: React.FC = () => {
+
+    const activities = [
+    { id: 1, title: "Activity number 1" },
+    { id: 2, title: "Activity number 2" },
+    { id: 3, title: "Activity number 3" }
+  ];
+
+
+  return (
+    <div className={styles['student-module-activities-card']}>
+        <h2 className={styles['student-module-activities-title']}>Activities</h2>
+
+      {activities.map(activity => (
+        <p key={activity.id}>{activity.title}</p>
+      ))}
+
+    </div>
+  );
+};
+
+export default StudentModuleActivities;

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -1,16 +1,36 @@
 import styles from './StudentModuleActivities.module.css';
 import { StudentActivityCard } from '../StudentActivityCard/StudentActivityCard';
+import { useEffect, useState } from 'react';
 
-export function StudentModuleActivities() {
-  const activities = [
-    { id: 1, title: 'Activity number 1' },
-    { id: 2, title: 'Activity number 2' },
-    { id: 3, title: 'Activity number 3' },
-  ];
+interface Activity {
+  id: number;
+  title: string;
+  description?: string;
+}
+
+interface StudentModuleActivitiesProps {
+  moduleId: string;
+}
+
+export function StudentModuleActivities({ moduleId }: StudentModuleActivitiesProps) {
+  const [activities, setActivities] = useState<Activity[]>([]);
+
+  useEffect(() => {
+    // Här kan du göra fetch från backend med moduleId
+    // Just nu använder vi dummy-data
+    const dummyActivities: Activity[] = [
+      { id: 1, title: `Activity 1 for module ${moduleId}` },
+      { id: 2, title: `Activity 2 for module ${moduleId}` },
+      { id: 3, title: `Activity 3 for module ${moduleId}` },
+    ];
+    setActivities(dummyActivities);
+  }, [moduleId]);
 
   return (
     <div className={styles['student-module-activities-card']}>
-      <h2 className={styles['student-module-activities-title']}>Activities for the module</h2>
+      <h2 className={styles['student-module-activities-title']}>
+        Activities for module {moduleId}
+      </h2>
 
       {activities.map((activity) => (
         <StudentActivityCard key={activity.id} title={activity.title} />

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -35,10 +35,7 @@ export function StudentModuleActivities({
 
   useEffect(() => {
     if (moduleId && studentId) {
-      console.log('Fetching activities from:', endpoint);
-      requestFunc().then(() => {
-        console.log('Fetched activities data:', data);
-      });
+      requestFunc().then(() => {});
     }
   }, [moduleId, studentId]);
 
@@ -57,17 +54,20 @@ export function StudentModuleActivities({
       </h2>
 
       {data
-      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-      .map((activity) => (
-        <StudentActivityCard
-          key={activity.id}
-          activityTitle={activity.activityTitle}
-          description={activity.description}
-          startDate={activity.startDate}
-          endDate={activity.endDate}
-          activityTypeName={activity.activityTypeName}
-        />
-      ))}
+        .sort(
+          (a, b) =>
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+        )
+        .map((activity) => (
+          <StudentActivityCard
+            key={activity.id}
+            activityTitle={activity.activityTitle}
+            description={activity.description}
+            startDate={activity.startDate}
+            endDate={activity.endDate}
+            activityTypeName={activity.activityTypeName}
+          />
+        ))}
     </div>
   );
 }

--- a/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
+++ b/src/features/shared/components/StudentModuleActivities/StudentModuleActivities.tsx
@@ -1,39 +1,70 @@
 import styles from './StudentModuleActivities.module.css';
 import { StudentActivityCard } from '../StudentActivityCard/StudentActivityCard';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useAuthContext } from '../../../auth/hooks/useAuthContext';
+import { useFetchWithToken } from '../../hooks/useFetchWithToken';
+import { BASE_URL } from '../../constants';
 
 interface Activity {
-  id: number;
-  title: string;
-  description?: string;
+  id: string;
+  moduleId: string;
+  activityTypeId: string;
+  activityTitle: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  activityTypeName: string;
 }
 
 interface StudentModuleActivitiesProps {
   moduleId: string;
+  moduleTitle: string;
 }
 
-export function StudentModuleActivities({ moduleId }: StudentModuleActivitiesProps) {
-  const [activities, setActivities] = useState<Activity[]>([]);
+export function StudentModuleActivities({
+  moduleId,
+  moduleTitle,
+}: StudentModuleActivitiesProps) {
+  const { user } = useAuthContext();
+  const studentId = user?.id;
+  const endpoint = studentId
+    ? `${BASE_URL}/student/${studentId}/module/${moduleId}/activities`
+    : '';
+  const { data, error, isLoading, requestFunc } =
+    useFetchWithToken<Activity[]>(endpoint);
 
   useEffect(() => {
-    // Här kan du göra fetch från backend med moduleId
-    // Just nu använder vi dummy-data
-    const dummyActivities: Activity[] = [
-      { id: 1, title: `Activity 1 for module ${moduleId}` },
-      { id: 2, title: `Activity 2 for module ${moduleId}` },
-      { id: 3, title: `Activity 3 for module ${moduleId}` },
-    ];
-    setActivities(dummyActivities);
-  }, [moduleId]);
+    if (moduleId && studentId) {
+      console.log('Fetching activities from:', endpoint);
+      requestFunc().then(() => {
+        console.log('Fetched activities data:', data);
+      });
+    }
+  }, [moduleId, studentId]);
+
+  if (!studentId) return <p className={styles.message}>No student ID found.</p>;
+  if (isLoading) return <p className={styles.message}>Loading activities...</p>;
+  if (error) return <p className={styles.message}>Error: {error.message}</p>;
+  if (!data)
+    return (
+      <p className={styles.message}>No activities found for this module.</p>
+    );
 
   return (
     <div className={styles['student-module-activities-card']}>
       <h2 className={styles['student-module-activities-title']}>
-        Activities for module {moduleId}
+        Activities for module {moduleTitle}
       </h2>
 
-      {activities.map((activity) => (
-        <StudentActivityCard key={activity.id} title={activity.title} />
+      {data.map((activity) => (
+        <StudentActivityCard
+          key={activity.id}
+          activityTitle={activity.activityTitle}
+          description={activity.description}
+          startDate={activity.startDate}
+          endDate={activity.endDate}
+          activityTypeName={activity.activityTypeName}
+        />
       ))}
     </div>
   );

--- a/src/features/shared/components/StudentModuleList/ModuleList.tsx
+++ b/src/features/shared/components/StudentModuleList/ModuleList.tsx
@@ -4,18 +4,33 @@ import { Module } from '../../../auth/types';
 
 interface ModuleListProps {
   modules: Module[];
+  onSelectModule?: (moduleId: string) => void;
 }
 
-export const ModuleList: React.FC<ModuleListProps> = ({ modules }) => (
+export const ModuleList: React.FC<ModuleListProps> = ({
+  modules,
+  onSelectModule,
+}) => (
   <ul className={styles.moduleList}>
     {[...modules]
-      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+      .sort(
+        (a, b) =>
+          new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+      )
       .map((module) => (
-        <li key={module.id} className={styles.moduleItem}>
-          <div><strong>{module.name}</strong></div>
+        <li
+          key={module.id}
+          className={styles.moduleItem}
+          onClick={() => onSelectModule?.(module.id)}
+          style={{ cursor: 'pointer' }}
+        >
+          <div>
+            <strong>{module.name}</strong>
+          </div>
           <div>{module.description}</div>
           <div>
-            <span>Start: {module.startDate}</span> | <span>End: {module.endDate}</span>
+            <span>Start: {module.startDate}</span> |{' '}
+            <span>End: {module.endDate}</span>
           </div>
         </li>
       ))}

--- a/src/features/shared/components/StudentModuleList/ModuleList.tsx
+++ b/src/features/shared/components/StudentModuleList/ModuleList.tsx
@@ -4,7 +4,7 @@ import { Module } from '../../../auth/types';
 
 interface ModuleListProps {
   modules: Module[];
-  onSelectModule?: (moduleId: string) => void;
+  onSelectModule?: (module: { id: string; moduleTitle: string }) => void;
 }
 
 export const ModuleList: React.FC<ModuleListProps> = ({
@@ -21,7 +21,7 @@ export const ModuleList: React.FC<ModuleListProps> = ({
         <li
           key={module.id}
           className={styles.moduleItem}
-          onClick={() => onSelectModule?.(module.id)}
+          onClick={() => onSelectModule?.({ id: module.id, moduleTitle: module.name })}
           style={{ cursor: 'pointer' }}
         >
           <div>

--- a/src/features/shared/components/StudentModuleList/StudentModuleList.module.css
+++ b/src/features/shared/components/StudentModuleList/StudentModuleList.module.css
@@ -68,3 +68,12 @@
   font-size: 1rem;
   margin: 16px 0;
 }
+
+.link {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  text-decoration: none;
+  color: inherit;
+}
+

--- a/src/features/shared/components/StudentModuleList/StudentModuleList.tsx
+++ b/src/features/shared/components/StudentModuleList/StudentModuleList.tsx
@@ -7,14 +7,19 @@ import { ModuleList } from './ModuleList';
 import { BASE_URL } from '../../constants';
 
 interface StudentModuleListProps {
-  onSelectModule?: (moduleId: string) => void;
+  onSelectModule?: (module: { id: string; moduleTitle: string }) => void;
 }
 
-export const StudentModuleList: React.FC<StudentModuleListProps> = ({ onSelectModule }) => {
+export const StudentModuleList: React.FC<StudentModuleListProps> = ({
+  onSelectModule,
+}) => {
   const { user } = useAuthContext();
   const studentId = user?.id;
-  const endpoint = studentId ? `${BASE_URL}/student/${studentId}/course-with-modules` : '';
-  const { data, error, isLoading, requestFunc } = useFetchWithToken<CourseWithModules>(endpoint);
+  const endpoint = studentId
+    ? `${BASE_URL}/student/${studentId}/course-with-modules`
+    : '';
+  const { data, error, isLoading, requestFunc } =
+    useFetchWithToken<CourseWithModules>(endpoint);
 
   useEffect(() => {
     if (studentId) {
@@ -23,9 +28,11 @@ export const StudentModuleList: React.FC<StudentModuleListProps> = ({ onSelectMo
   }, [studentId]);
 
   if (!studentId) return <p className={styles.message}>No student ID found.</p>;
-  if (isLoading) return <p className={styles.message}>Loading course and modules...</p>;
+  if (isLoading)
+    return <p className={styles.message}>Loading course and modules...</p>;
   if (error) return <p className={styles.message}>Error: {error.message}</p>;
-  if (!data) return <p className={styles.message}>No course found for this student.</p>;
+  if (!data)
+    return <p className={styles.message}>No course found for this student.</p>;
 
   // Render the list of modules that belong to the student's course
   return (
@@ -38,4 +45,3 @@ export const StudentModuleList: React.FC<StudentModuleListProps> = ({ onSelectMo
     </div>
   );
 };
-

--- a/src/features/shared/components/StudentModuleList/StudentModuleList.tsx
+++ b/src/features/shared/components/StudentModuleList/StudentModuleList.tsx
@@ -6,7 +6,11 @@ import { CourseWithModules } from '../../../auth/types';
 import { ModuleList } from './ModuleList';
 import { BASE_URL } from '../../constants';
 
-export const StudentModuleList: React.FC = () => {
+interface StudentModuleListProps {
+  onSelectModule?: (moduleId: string) => void;
+}
+
+export const StudentModuleList: React.FC<StudentModuleListProps> = ({ onSelectModule }) => {
   const { user } = useAuthContext();
   const studentId = user?.id;
   const endpoint = studentId ? `${BASE_URL}/student/${studentId}/course-with-modules` : '';
@@ -27,7 +31,7 @@ export const StudentModuleList: React.FC = () => {
   return (
     <div>
       {data.modules && data.modules.length > 0 ? (
-        <ModuleList modules={data.modules} />
+        <ModuleList modules={data.modules} onSelectModule={onSelectModule} />
       ) : (
         <p className={styles.message}>No modules found for this course.</p>
       )}


### PR DESCRIPTION
Implements the ability for students to view activities related to a selected module in a schedule format.

- Adds `StudentModuleActivities` component to fetch and display activities for a selected module.
- Introduces `StudentActivityCard` for rendering individual activity details (title, description, type, start/end dates).
- Integrates the feature into the student dashboard, allowing module selection and showing associated activities.
- Handles loading, error, and empty states.
- Activities are sorted by start date for easy schedule viewing.