### PR TITLE
Add course search and editing

### DIFF
--- a/src/features/admin/components/AdminPage.tsx
+++ b/src/features/admin/components/AdminPage.tsx
@@ -7,8 +7,9 @@ import { UserDisplay } from "./FetchResults";
 import { AdminForm } from "./UserAdminForm";
 import { ModuleForm } from "./ModuleForm";
 import { useAdminContext } from "../context/adminProvider";
-import { CourseCreate } from "../courses/components";
+import { CourseCreate, CourseEdit } from "../courses/components";
 import "../css/admin.css";
+import { CourseFetchForm } from "./CourseFetchForm";
 
 export function AdminPage(): ReactElement {
   const [adminPanel, setAdminPanel] = useState<AdminPanelState>({
@@ -18,8 +19,10 @@ export function AdminPage(): ReactElement {
     editMode: false,
     assign: false,
     registerCourse: false,
+    editCourse: false,
   });
   const [showModuleForm, setShowModuleForm] = useState(false);
+  const [showFindCourse, setShowFindCourse] = useState(false);
   const [editModule, setEditModule] = useState<IModule | undefined>(undefined); // For editing existing module
   const { user, setUser, token } = useAdminContext();
 
@@ -31,6 +34,7 @@ export function AdminPage(): ReactElement {
           onClick={() => {
             setUser(undefined);
             setShowModuleForm(false);
+            setShowFindCourse(false);
             setAdminPanel({
               fetch: true,
               display: false,
@@ -38,6 +42,7 @@ export function AdminPage(): ReactElement {
               editMode: false,
               assign: false,
               registerCourse: false,
+              editCourse: false,
             });
           }}
         >
@@ -47,6 +52,7 @@ export function AdminPage(): ReactElement {
           onClick={() => {
             setUser(undefined);
             setShowModuleForm(false);
+            setShowFindCourse(false);
             setAdminPanel({
               fetch: false,
               display: false,
@@ -54,6 +60,7 @@ export function AdminPage(): ReactElement {
               editMode: false,
               assign: false,
               registerCourse: false,
+              editCourse: false,
             });
           }}
         >
@@ -61,7 +68,26 @@ export function AdminPage(): ReactElement {
         </button>
         <button
           onClick={() => {
+            setUser(undefined);
             setShowModuleForm(false);
+            setShowFindCourse(true);
+            setAdminPanel({
+              fetch: false,
+              display: false,
+              register: false,
+              editMode: false,
+              assign: false,
+              registerCourse: false,
+              editCourse: false,
+            });
+          }}
+        >
+          Find a Course
+        </button>
+        <button
+          onClick={() => {
+            setShowModuleForm(false);
+            setShowFindCourse(false);
             setAdminPanel({
               fetch: false,
               display: false,
@@ -69,6 +95,7 @@ export function AdminPage(): ReactElement {
               editMode: false,
               assign: false,
               registerCourse: true,
+              editCourse: false,
             });
           }}
         >
@@ -77,6 +104,7 @@ export function AdminPage(): ReactElement {
         <button
           onClick={() => {
             setShowModuleForm(true);
+            setShowFindCourse(false);
             setAdminPanel({
               fetch: false,
               display: false,
@@ -84,6 +112,7 @@ export function AdminPage(): ReactElement {
               editMode: false,
               assign: false,
               registerCourse: false,
+              editCourse: false,
             });
           }}
         >
@@ -93,39 +122,38 @@ export function AdminPage(): ReactElement {
       <div className="admin-area">
         <div className="left-side">
           {adminPanel.fetch && !adminPanel.register && (
-            <FetchForm
-              legend={"Find an account"}
-              onClose={() => setAdminPanel({ ...adminPanel, fetch: false })}
-            />
+            <FetchForm legend={"Find an account"} onClose={() => setAdminPanel({ ...adminPanel, fetch: false })} />
           )}
           {user && !adminPanel.register && (
             <UserDisplay
               legend="User Info"
               onEdit={() => setAdminPanel({ ...adminPanel, editMode: true })}
               onClose={() => setAdminPanel({ ...adminPanel, display: false })}
-              onReassign={() =>
-                setAdminPanel({ ...adminPanel, assign: true, editMode: false })
-              }
+              onReassign={() => setAdminPanel({ ...adminPanel, assign: true, editMode: false })}
+            />
+          )}
+
+          {showFindCourse && (
+            <CourseFetchForm
+              onEdit={(course) => {
+                console.log(course.id);
+                setAdminPanel({ ...adminPanel, editCourse: true });
+              }}
             />
           )}
         </div>
         <div className="right-side">
           {adminPanel.editMode && !adminPanel.register && (
-            <AdminForm
-              legend="Edit User"
-              onClose={() => setAdminPanel({ ...adminPanel, editMode: false })}
-            />
+            <AdminForm legend="Edit User" onClose={() => setAdminPanel({ ...adminPanel, editMode: false })} />
           )}
           {adminPanel.register && (
             <AdminForm
               legend="Register User"
-              onClose={() =>
-                setAdminPanel({ ...adminPanel, register: false, display: true })
-              }
+              onClose={() => setAdminPanel({ ...adminPanel, register: false, display: true })}
             />
           )}
           {showModuleForm && (
-            <div style={{flex: 1}}>
+            <div style={{ flex: 1 }}>
               <ModuleForm
                 token={token ?? ""}
                 onClose={() => {
@@ -143,14 +171,10 @@ export function AdminPage(): ReactElement {
         </div>
         <div>
           {adminPanel.assign && (
-            <AssignCourse
-              legend="Assign Course"
-              onClose={() => setAdminPanel({ ...adminPanel, assign: false })}
-            />
+            <AssignCourse legend="Assign Course" onClose={() => setAdminPanel({ ...adminPanel, assign: false })} />
           )}
-          {adminPanel.registerCourse && (
-            <CourseCreate/>
-          )}
+          {adminPanel.registerCourse && <CourseCreate />}
+          {adminPanel.editCourse && <CourseEdit />}
         </div>
       </div>
     </main>

--- a/src/features/admin/components/AdminPage.tsx
+++ b/src/features/admin/components/AdminPage.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { AdminPanelState } from "../types";
+import { AdminPanelState, ICourse } from "../types";
 import { IModule } from "../types/modules";
 import { FetchForm } from "./UserFetchForm";
 import { AssignCourse } from "./UserAssignForm";
@@ -24,6 +24,7 @@ export function AdminPage(): ReactElement {
   const [showModuleForm, setShowModuleForm] = useState(false);
   const [showFindCourse, setShowFindCourse] = useState(false);
   const [editModule, setEditModule] = useState<IModule | undefined>(undefined); // For editing existing module
+  const [editCourse, setEditCourse] = useState<ICourse | undefined>(undefined);
   const { user, setUser, token } = useAdminContext();
 
   return (
@@ -136,7 +137,7 @@ export function AdminPage(): ReactElement {
           {showFindCourse && (
             <CourseFetchForm
               onEdit={(course) => {
-                console.log(course.id);
+                setEditCourse(course);
                 setAdminPanel({ ...adminPanel, editCourse: true });
               }}
             />
@@ -174,7 +175,7 @@ export function AdminPage(): ReactElement {
             <AssignCourse legend="Assign Course" onClose={() => setAdminPanel({ ...adminPanel, assign: false })} />
           )}
           {adminPanel.registerCourse && <CourseCreate />}
-          {adminPanel.editCourse && <CourseEdit />}
+          {adminPanel.editCourse && editCourse && <CourseEdit course={editCourse} />}
         </div>
       </div>
     </main>

--- a/src/features/admin/components/CourseFetchForm.tsx
+++ b/src/features/admin/components/CourseFetchForm.tsx
@@ -49,20 +49,17 @@ export function CourseFetchForm({ onEdit }: CourseFetchFormProps): ReactElement 
 
       {courses.length > 0 && (
         <div className="courses-list">
-          <h2>Found Courses ({courses.length})</h2>
           <ul>
             {courses.map((course) => (
-              <li key={course.id}>
-                <div className="course-item">
-                  <h3>{course.name}</h3>
-                  {course.description && <p>{course.description}</p>}
-                  <p>Start date: {course.startDate}</p>
-                  <p>End date: {course.endDate}</p>
-                  <button className="edit-button" onClick={() => handleEdit(course)}>
-                    Edit
-                  </button>
-                </div>
-              </li>
+              <div key={course.id} className="course-item">
+                <h3>{course.name}</h3>
+                {course.description && <p>{course.description}</p>}
+                <p>Start date: {course.startDate}</p>
+                <p>End date: {course.endDate}</p>
+                <button className="edit-button" onClick={() => handleEdit(course)}>
+                  Edit
+                </button>
+              </div>
             ))}
           </ul>
         </div>

--- a/src/features/admin/components/CourseFetchForm.tsx
+++ b/src/features/admin/components/CourseFetchForm.tsx
@@ -1,0 +1,72 @@
+import { FormEventHandler, ReactElement, useState } from "react";
+import "../css/styles.css";
+import { useAdminContext } from "../context/adminProvider";
+import { ICourse } from "../types";
+import { searchCourses } from "../courses/api";
+
+interface CourseFetchFormProps {
+  onEdit: (course: ICourse) => void;
+}
+
+export function CourseFetchForm({ onEdit }: CourseFetchFormProps): ReactElement {
+  const [courses, setCourses] = useState<ICourse[]>([]);
+  const [name, setName] = useState<string>("");
+  const [notFound, setNotFound] = useState<boolean>(false);
+  const { token } = useAdminContext();
+
+  const handleOnSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+
+    if (!token) {
+      console.error("No token available");
+      return;
+    }
+
+    const results = await searchCourses(name, token);
+    if (results && results.length > 0) {
+      setCourses(results);
+      setNotFound(false);
+    } else {
+      setNotFound(true);
+    }
+  };
+
+  const handleEdit = (course: ICourse) => {
+    onEdit(course);
+  };
+
+  return (
+    <main className="form-page">
+      <form className="form" onSubmit={handleOnSubmit}>
+        <fieldset>
+          <legend>Find a course</legend>
+          <label htmlFor="name">Course name</label>
+          <input id="name" name="name" value={name} onChange={(e) => setName(e.target.value)} type="text" required />
+          <button type="submit">Find Course</button>
+          {notFound && <p style={{ color: "red" }}> Course not found</p>}
+        </fieldset>
+      </form>
+
+      {courses.length > 0 && (
+        <div className="courses-list">
+          <h2>Found Courses ({courses.length})</h2>
+          <ul>
+            {courses.map((course) => (
+              <li key={course.id}>
+                <div className="course-item">
+                  <h3>{course.name}</h3>
+                  {course.description && <p>{course.description}</p>}
+                  <p>Start date: {course.startDate}</p>
+                  <p>End date: {course.endDate}</p>
+                  <button className="edit-button" onClick={() => handleEdit(course)}>
+                    Edit
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/features/admin/courses/api/index.ts
+++ b/src/features/admin/courses/api/index.ts
@@ -40,3 +40,17 @@ export async function getCourses(token: string): Promise<ICourse[]> {
   }
   return await response.json();
 }
+
+export async function searchCourses(query: string, token: string): Promise<ICourse[]> {
+  const url = `${BASE_URL}/courses/search?query=${encodeURIComponent(query)}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    throw new CustomError(response.status, "Failed to fetch courses");
+  }
+  return await response.json();
+}

--- a/src/features/admin/courses/components/CourseEdit.tsx
+++ b/src/features/admin/courses/components/CourseEdit.tsx
@@ -7,10 +7,11 @@ import { fetchWithToken } from "../../../shared/utilities";
 import { Course } from "../../../auth/types";
 import { BASE_URL } from "../../../shared/constants";
 
-export const CourseEdit = (): ReactElement => {
-  const { course } = useLoaderData<ICourseLoader>();
-  const { id } = useParams();
+interface CourseEditProps {
+  course: ICourse;
+}
 
+export const CourseEdit = ({ course }: CourseEditProps): ReactElement => {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -21,14 +22,14 @@ export const CourseEdit = (): ReactElement => {
     endDate: string;
   }) => {
     try {
-      await fetchWithToken<Course>(`${BASE_URL}/courses/${id}`, {
+      await fetchWithToken<Course>(`${BASE_URL}/courses/${course.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
           ...courseData,
-          id: id,
+          id: course.id,
         }),
       });
 
@@ -42,8 +43,8 @@ export const CourseEdit = (): ReactElement => {
   return (
     <>
       <main id="create-course">
-        <Suspense>
-          <h1>Edit course</h1>
+        <fieldset>
+          <legend>Edit course</legend>
           <div className="form-wrapper">
             {successMessage && <div className="alert alert-success">{successMessage}</div>}
             {errorMessage && <div className="alert alert-error">{errorMessage}</div>}
@@ -52,7 +53,7 @@ export const CourseEdit = (): ReactElement => {
               {(course: ICourse) => <CourseForm course={course} onSubmit={handleOnSubmit} />}
             </Await>
           </div>
-        </Suspense>
+        </fieldset>
       </main>
     </>
   );

--- a/src/features/admin/types/index.ts
+++ b/src/features/admin/types/index.ts
@@ -1,5 +1,5 @@
-export * from './forms';
-export * from './users';
+export * from "./forms";
+export * from "./users";
 
 export interface AdminPanelState {
   fetch: boolean;
@@ -7,5 +7,6 @@ export interface AdminPanelState {
   register: boolean;
   registerCourse: boolean;
   editMode: boolean;
-  assign: boolean
+  assign: boolean;
+  editCourse: boolean;
 }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -24,8 +24,6 @@ export const router = createBrowserRouter(
             </RequireRole>
           }
         >
-          <Route path="courses/new" element={<CourseCreate />} />
-          <Route path="courses/:id/edit" element={<CourseEdit />} loader={courseLoader} />
           <Route
             path="admin"
             element={


### PR DESCRIPTION
Adds the ability to search for courses and edit them directly within the admin panel, eliminating the need for separate route-based course editing pages.

Removed unused course editing routes (`/courses/new,` `courses/:id/edit`)